### PR TITLE
fix library if no configure is called

### DIFF
--- a/watchman.go
+++ b/watchman.go
@@ -24,8 +24,8 @@ type Client struct {
 	configured   bool
 }
 
-var defaultClient ClientI
-var externalClient externalClientConvinience
+var defaultClient ClientI = &Client{}
+var externalClient externalClientConvinience = externalClientConvinience{&Client{}}
 
 type Options struct {
 	Host                  string


### PR DESCRIPTION
if watchman is not configured it should return an error it is not returned and not access to nill pointer, this fixes watchman in tests, bug was made in #5 